### PR TITLE
Modernize the code

### DIFF
--- a/examples/swap-macro.js
+++ b/examples/swap-macro.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-var recast = require('recast');
-var util = require('../lib');
-var types = util.types;
-var n = types.namedTypes;
-var b = types.builders;
-var assert = require('assert');
+const recast = require('recast');
+const util = require('../lib');
+const { types } = util;
+const n = types.namedTypes;
+const b = types.builders;
+const assert = require('assert');
 
 /**
  * Treats calls to `swap` as a macro to swap the identifiers passed to swap.
@@ -23,28 +23,28 @@ var assert = require('assert');
  * @return {ast-types.Node} Returns `ast`.
  */
 function transform(ast) {
-  var replaced = [];
+  const replaced = [];
 
   types.traverse(ast, function(node) {
     if (n.ExpressionStatement.check(node)) {
       if (isSwapCall(this.get('expression'))) {
         // swap(left, right)
-        var expression = node.expression;
-        assert.equal(expression.arguments.length, 2, 'expected 2 arguments to `swap`, got ' + expression.arguments.length);
+        const { expression } = node;
+        assert.equal(expression.arguments.length, 2, `expected 2 arguments to \`swap\`, got ${expression.arguments.length}`);
 
-        var left = expression.arguments[0];
-        var right = expression.arguments[1];
+        const left = expression.arguments[0];
+        const right = expression.arguments[1];
 
         assert.ok(
           n.Identifier.check(left) || n.MemberExpression.check(left),
-          'expected first argument of `swap` to be an Identifier or MemberExpression, found ' + left.type
+          `expected first argument of \`swap\` to be an Identifier or MemberExpression, found ${left.type}`
         );
         assert.ok(
           n.Identifier.check(right) || n.MemberExpression.check(right),
-          'expected second argument of `swap` to be an Identifier or MemberExpression, found ' + right.type
+          `expected second argument of \`swap\` to be an Identifier or MemberExpression, found ${right.type}`
         );
 
-        var tmp = util.uniqueIdentifier(this.scope);
+        const tmp = util.uniqueIdentifier(this.scope);
 
         replaced.push(expression);
         this.replace(
@@ -80,12 +80,12 @@ function isSwapCall(path) {
 }
 
 function readStdin(callback) {
-  var stdin = '';
+  let stdin = '';
 
   process.stdin.setEncoding('utf8');
 
   process.stdin.on('readable', function() {
-    var chunk = process.stdin.read();
+    const chunk = process.stdin.read();
     if (chunk !== null) {
       stdin += chunk;
     }

--- a/helpers/get.js
+++ b/helpers/get.js
@@ -1,7 +1,7 @@
 (function get(object, property, receiver) {
-  var desc = Object.getOwnPropertyDescriptor(object, property);
+  const desc = Object.getOwnPropertyDescriptor(object, property);
   if (desc === void 0) {
-    var parent = Object.getPrototypeOf(object);
+    const parent = Object.getPrototypeOf(object);
     if (parent === null) {
       return void 0;
     } else {
@@ -10,7 +10,7 @@
   } else if ('value' in desc && 'writable' in desc) {
     return desc.value;
   } else {
-    var getter = desc.get;
+    const getter = desc.get;
     if (getter === void 0) {
       return void 0;
     }

--- a/helpers/getArrayIterator.js
+++ b/helpers/getArrayIterator.js
@@ -1,7 +1,7 @@
 (function(array) {
-  var index = 0;
+  let index = 0;
   return {
-    next: function() {
+    next() {
       if (index < array.length) {
         return {
           done: false,

--- a/helpers/getIterator.js
+++ b/helpers/getIterator.js
@@ -1,5 +1,5 @@
 (function(iterable) {
-  var sym = typeof Symbol === "function" && Symbol.iterator || "@@iterator";
+  const sym = typeof Symbol === "function" && Symbol.iterator || "@@iterator";
 
   if (typeof iterable[sym] === "function") {
     return iterable[sym]();

--- a/helpers/getIteratorRange.js
+++ b/helpers/getIteratorRange.js
@@ -6,9 +6,9 @@
     len = Infinity;
   }
 
-  var range = [], end = begin + len;
+  const range = [], end = begin + len;
   while (index < end) {
-    var next = iterator.next();
+    const next = iterator.next();
     if (next.done) {
       break;
     }
@@ -19,7 +19,7 @@
   }
 
   return {
-    range: range,
-    index: index
+    range,
+    index
   };
 });

--- a/lib/helpers/get.js
+++ b/lib/helpers/get.js
@@ -1,6 +1,6 @@
-var b = require('ast-types').builders;
-module.exports = function(scope) {
-  return b.functionExpression(
+const b = require('ast-types').builders;
+module.exports = scope =>
+  b.functionExpression(
   b.identifier('get'),
   [
     b.identifier('object'),
@@ -157,4 +157,4 @@ module.exports = function(scope) {
   ]),
   false,
   false
-)};
+);

--- a/lib/helpers/getArrayIterator.js
+++ b/lib/helpers/getArrayIterator.js
@@ -1,6 +1,6 @@
-var b = require('ast-types').builders;
-module.exports = function(scope) {
-  return b.functionExpression(
+const b = require('ast-types').builders;
+module.exports = scope =>
+  b.functionExpression(
   null,
   [b.identifier('array')],
   b.blockStatement([
@@ -87,4 +87,4 @@ module.exports = function(scope) {
   ]),
   false,
   false
-)};
+);

--- a/lib/helpers/getIterator.js
+++ b/lib/helpers/getIterator.js
@@ -1,6 +1,6 @@
-var b = require('ast-types').builders;
+const b = require('ast-types').builders;
 module.exports = function(scope) {
-  var getArrayIterator = require('..').getArrayIterator;
+  const { getArrayIterator } = require('..');
 
   return b.functionExpression(
   null,

--- a/lib/helpers/getIteratorRange.js
+++ b/lib/helpers/getIteratorRange.js
@@ -1,6 +1,6 @@
-var b = require('ast-types').builders;
-module.exports = function(scope) {
-  return b.functionExpression(
+const b = require('ast-types').builders;
+module.exports = scope =>
+  b.functionExpression(
   null,
   [
     b.identifier('iterator'),
@@ -147,4 +147,4 @@ module.exports = function(scope) {
   ]),
   false,
   false
-)};
+);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,14 @@
 /* jshint node:true, undef:true, unused:true */
 
-var types = require('ast-types');
-var b = types.builders;
-var n = types.namedTypes;
-var NodePath = types.NodePath;
+const types = require('ast-types');
+const b = types.builders;
+const n = types.namedTypes;
+const { NodePath } = types;
 
-var getSecret = require('private').makeAccessor();
-var hasOwnProp = Object.prototype.hasOwnProperty;
+const getSecret = require('private').makeAccessor();
+const hasOwnProp = Object.prototype.hasOwnProperty;
 
-var assert = require('assert');
+const assert = require('assert');
 
 /**
  * Re-export ast-types for ease of our users.
@@ -39,7 +39,7 @@ function callArraySlice(scope, node, begin, end) {
     end = b.literal(end);
   }
 
-  var args = [];
+  const args = [];
   if (begin) { args.push(begin); }
   if (end) { args.push(end); }
 
@@ -64,7 +64,7 @@ exports.callArraySlice = callArraySlice;
  * @return {CallExpression}
  */
 function callFunctionBind(scope, fn, context, args) {
-  var bind = sharedFor(scope, 'Function.prototype.bind');
+  const bind = sharedFor(scope, 'Function.prototype.bind');
 
   if (n.Expression.check(args)) {
     return b.callExpression(
@@ -95,7 +95,7 @@ exports.callFunctionBind = callFunctionBind;
  * @return {CallExpression}
  */
 function callGetIterator(scope, expression) {
-  var getIterator = injectGetIteratorHelper(scope.getGlobalScope());
+  const getIterator = injectGetIteratorHelper(scope.getGlobalScope());
   return b.callExpression(getIterator, [expression]);
 }
 exports.callGetIterator = callGetIterator;
@@ -124,7 +124,7 @@ exports.getArrayIterator = getArrayIterator;
  * @return {CallExpression}
  */
 function callGetIteratorRange(scope, iterator, index, begin, len) {
-  var getIteratorRange = injectGetIteratorRangeHelper(scope.getGlobalScope());
+  const getIteratorRange = injectGetIteratorRangeHelper(scope.getGlobalScope());
   return b.callExpression(getIteratorRange, [iterator, index, begin, len]);
 }
 exports.callGetIteratorRange = callGetIteratorRange;
@@ -139,7 +139,7 @@ exports.callGetIteratorRange = callGetIteratorRange;
  * @return {CallExpression}
  */
 function callGet(scope, object, property, receiver) {
-  var get = injectGetHelper(scope.getGlobalScope());
+  const get = injectGetHelper(scope.getGlobalScope());
   return b.callExpression(get, [object, property, receiver]);
 }
 exports.callGet = callGet;
@@ -261,13 +261,13 @@ exports.callSharedMethodWithContext = callSharedMethodWithContext;
  * @return {Array.<Identifier>}
  */
 function getGlobals(ast) {
-  var globals = [];
-  var seen = Object.create(null);
+  const globals = [];
+  const seen = Object.create(null);
 
   types.visit(ast, {
-    visitNode: function(path) {
+    visitNode(path) {
       this.traverse(path);
-      var node = path.value;
+      const node = path.value;
 
       if (isReference(path) && !path.scope.lookup(node.name)) {
         if (!(node.name in seen)) {
@@ -304,9 +304,7 @@ function injectGetHelper(scope) {
   return injectShared(
     scope,
     'get',
-    function() {
-      return require('./helpers/get')(scope);
-    }
+    () => require('./helpers/get')(scope)
   );
 }
 
@@ -320,9 +318,7 @@ function injectGetArrayIteratorHelper(scope) {
   return injectShared(
     scope,
     'getArrayIterator',
-    function() {
-      return require('./helpers/getArrayIterator')(scope);
-    }
+    () => require('./helpers/getArrayIterator')(scope)
   );
 }
 
@@ -336,9 +332,7 @@ function injectGetIteratorHelper(scope) {
   return injectShared(
     scope,
     'getIterator',
-    function() {
-      return require('./helpers/getIterator')(scope);
-    }
+    () => require('./helpers/getIterator')(scope)
   );
 }
 
@@ -352,9 +346,7 @@ function injectGetIteratorRangeHelper(scope) {
   return injectShared(
     scope,
     'getIteratorRange',
-    function() {
-      return require('./helpers/getIteratorRange')(scope);
-    }
+    () => require('./helpers/getIteratorRange')(scope)
   );
 }
 
@@ -371,7 +363,7 @@ function injectGetIteratorRangeHelper(scope) {
  * @return {Identifier}
  */
 function injectShared(scope, name, expression) {
-  var scopeSecret = getSecret(scope);
+  const scopeSecret = getSecret(scope);
 
   if (!(name in scopeSecret)) {
     scopeSecret[name] = injectVariable(
@@ -397,17 +389,17 @@ exports.injectShared = injectShared;
  * @return {Identifier} Returns the given `identifier`.
  */
 function injectVariable(scope, identifier, init) {
-  var bodyPath = scope.path.get('body');
+  let bodyPath = scope.path.get('body');
 
   if (n.BlockStatement.check(bodyPath.value)) {
     bodyPath = bodyPath.get('body');
   }
 
-  var declarationIndex;
-  var bodyStatements = bodyPath.node.body;
+  let declarationIndex;
+  const bodyStatements = bodyPath.node.body;
 
   for (declarationIndex = 0; declarationIndex < bodyStatements.length; declarationIndex++) {
-    var statement = bodyStatements[declarationIndex];
+    const statement = bodyStatements[declarationIndex];
     if (!isDirectivePrologue(statement)) {
       break;
     }
@@ -422,8 +414,8 @@ function injectVariable(scope, identifier, init) {
   );
 
   // Ensure this identifier counts as used in this scope.
-  var name = identifier.name;
-  var bindings = scope.getBindings();
+  const { name } = identifier;
+  const bindings = scope.getBindings();
   if (!hasOwnProp.call(bindings, name)) {
     bindings[name] = [];
   }
@@ -442,7 +434,7 @@ exports.injectVariable = injectVariable;
  */
 function isDirectivePrologue(statement) {
   if (n.ExpressionStatement.check(statement)) {
-    var expression = statement.expression;
+    const { expression } = statement;
     if (n.Literal.check(expression)) {
       return typeof expression.value === 'string';
     }
@@ -464,13 +456,13 @@ function isDirectivePrologue(statement) {
  * @return {boolean}
  */
 function isReference(path, name) {
-  var node = path.value;
+  const node = path.value;
   assert.ok(n.Node.check(node));
 
   if (n.Identifier.check(node)) {
     if (name && node.name !== name) { return false; }
 
-    var parent = path.parent.value;
+    const parent = path.parent.value;
     if (n.VariableDeclarator.check(parent)) {
       return parent.init === node;
     } else if (n.MemberExpression.check(parent)) {
@@ -478,9 +470,7 @@ function isReference(path, name) {
         parent.computed && parent.property === node
       );
     } else if (n.Function.check(parent)) {
-      return parent.id !== node && !parent.params.some(function(param) {
-        return param === node;
-      });
+      return parent.id !== node && !parent.params.some(param => param === node);
     } else if (n.ClassDeclaration.check(parent) || n.ClassExpression.check(parent)) {
       return parent.id !== node;
     } else if (n.CatchClause.check(parent)) {
@@ -533,16 +523,14 @@ function isUsed(scope, name) {
     return true;
   }
 
-  var globalScope = scope.getGlobalScope();
-  var globalScopeSecret = getSecret(globalScope);
+  const globalScope = scope.getGlobalScope();
+  const globalScopeSecret = getSecret(globalScope);
 
   if (!globalScopeSecret.globals) {
     globalScopeSecret.globals = getGlobals(globalScope.node);
   }
 
-  return globalScopeSecret.globals.some(function(global) {
-    return global.name === name;
-  });
+  return globalScopeSecret.globals.some(global => global.name === name);
 }
 exports.isUsed = isUsed;
 
@@ -565,10 +553,10 @@ function sharedFor(scope, name) {
     scope,
     name,
     function() {
-      var parts = name.split('.');
-      var result = b.identifier(parts[0]);
+      const parts = name.split('.');
+      let result = b.identifier(parts[0]);
 
-      for (var i = 1, length = parts.length; i < length; i++) {
+      for (let i = 1, { length } = parts; i < length; i++) {
         result = b.memberExpression(
           result,
           b.identifier(parts[i]),
@@ -600,10 +588,10 @@ exports.sharedFor = sharedFor;
  * @see isUsed
  */
 function uniqueIdentifier(scope, name) {
-  var prefix = '$__' + identifierForString(name ? name : '');
-  var globalScopeSecret = getSecret(scope.getGlobalScope());
-  var n = globalScopeSecret.nextId || 0;
-  var identifier = name ? prefix : null;
+  const prefix = `$__${identifierForString(name ? name : '')}`;
+  const globalScopeSecret = getSecret(scope.getGlobalScope());
+  let n = globalScopeSecret.nextId || 0;
+  let identifier = name ? prefix : null;
 
   while (!identifier || isUsed(scope, identifier)) {
     identifier = prefix + n;

--- a/lib/replacement.js
+++ b/lib/replacement.js
@@ -18,8 +18,8 @@ function Replacement(nodePath, nodes) {
  * Performs the replacement.
  */
 Replacement.prototype.replace = function() {
-  for (var i = 0, length = this.queue.length; i < length; i++) {
-    var item = this.queue[i];
+  for (let i = 0, { length } = this.queue; i < length; i++) {
+    const item = this.queue[i];
     item[0].replace.apply(item[0], item[1]);
   }
 };
@@ -40,9 +40,7 @@ Replacement.prototype.and = function(anotherReplacement) {
  * @param {NodePath} nodePath
  * @returns {Replacement}
  */
-Replacement.removes = function(nodePath) {
-  return new Replacement(nodePath, []);
-};
+Replacement.removes = nodePath => new Replacement(nodePath, []);
 
 /**
  * Constructs a Replacement that, when run, will insert the given nodes after
@@ -52,9 +50,7 @@ Replacement.removes = function(nodePath) {
  * @param {Array.<Node>} nodes
  * @returns {Replacement}
  */
-Replacement.adds = function(nodePath, nodes) {
-  return new Replacement(nodePath, [nodePath.node].concat(nodes));
-};
+Replacement.adds = (nodePath, nodes) => new Replacement(nodePath, [nodePath.node].concat(nodes));
 
 /**
  * Constructs a Replacement that, when run, swaps the node in nodePath with the
@@ -80,10 +76,10 @@ Replacement.swaps = function(nodePath, nodes) {
  * @returns {Replacement}
  */
 Replacement.map = function(nodePaths, callback) {
-  var result = new Replacement();
+  const result = new Replacement();
 
   nodePaths.each(function(nodePath) {
-    var replacement = callback(nodePath);
+    const replacement = callback(nodePath);
     if (replacement) {
       result.and(replacement);
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,21 +2,21 @@
  * This file really only exists to make JSDoc/WebStorm happy.
  */
 
-var types = require('ast-types');
-var Scope = require('ast-types/lib/scope');
-var NodePath = types.NodePath;
+const types = require('ast-types');
+const Scope = require('ast-types/lib/scope');
+const { NodePath } = types;
 
 /** @typedef Object */
-var Node;
+let Node;
 
 /** @typedef Node */
-var Expression;
+let Expression;
 
 /** @typedef Expression */
-var CallExpression;
+let CallExpression;
 
 /** @typedef Expression */
-var Literal;
+let Literal;
 
 /** @typedef Expression */
-var Identifier;
+let Identifier;

--- a/test/replacement_test.js
+++ b/test/replacement_test.js
@@ -1,16 +1,16 @@
 /* jshint node:true, mocha:true, undef:true, unused:true */
 
-var Replacement = require('../lib').Replacement;
-var assert = require('assert');
+const { Replacement } = require('../lib');
+const assert = require('assert');
 
 describe('Replacement', function() {
-  var nodePath;
+  let nodePath;
 
   function makeNodePath() {
-    var node = {};
+    const node = {};
     return {
-      node: node,
-      replace: function() {
+      node,
+      replace() {
         this.replacedWith = [].slice.call(arguments);
       }
     };
@@ -22,7 +22,7 @@ describe('Replacement', function() {
 
   describe('.removes', function() {
     it('creates a Replacement that replaces with nothing', function() {
-      var repl = Replacement.removes(nodePath);
+      const repl = Replacement.removes(nodePath);
       repl.replace();
       assert.equal(nodePath.replacedWith.length, 0);
     });
@@ -30,17 +30,17 @@ describe('Replacement', function() {
 
   describe('.swaps', function() {
     it('creates a Replacement that replaces with another', function() {
-      var swappedIn = {};
-      var repl = Replacement.swaps(nodePath, swappedIn);
+      const swappedIn = {};
+      const repl = Replacement.swaps(nodePath, swappedIn);
       repl.replace();
       assert.equal(nodePath.replacedWith.length, 1);
       assert.strictEqual(nodePath.replacedWith[0], swappedIn);
     });
 
     it('creates a Replacement that replaces with a list', function() {
-      var swappedIn1 = {};
-      var swappedIn2 = {};
-      var repl = Replacement.swaps(nodePath, [swappedIn1, swappedIn2]);
+      const swappedIn1 = {};
+      const swappedIn2 = {};
+      const repl = Replacement.swaps(nodePath, [swappedIn1, swappedIn2]);
       repl.replace();
       assert.equal(nodePath.replacedWith.length, 2);
       assert.strictEqual(nodePath.replacedWith[0], swappedIn1);
@@ -50,9 +50,9 @@ describe('Replacement', function() {
 
   describe('.adds', function() {
     it('creates a Replacement that adds additional nodes', function() {
-      var added1 = {};
-      var added2 = {};
-      var repl = Replacement.adds(nodePath, [added1, added2]);
+      const added1 = {};
+      const added2 = {};
+      const repl = Replacement.adds(nodePath, [added1, added2]);
       repl.replace();
       assert.equal(nodePath.replacedWith.length, 3);
       assert.strictEqual(nodePath.replacedWith[0], nodePath.node);
@@ -62,11 +62,11 @@ describe('Replacement', function() {
   });
 
   describe('.map', function() {
-    var from1;
-    var from2;
-    var nodeArrayPath;
-    var to1;
-    var to2;
+    let from1;
+    let from2;
+    let nodeArrayPath;
+    let to1;
+    let to2;
 
     beforeEach(function() {
       from1 = makeNodePath();
@@ -78,13 +78,13 @@ describe('Replacement', function() {
     });
 
     it('creates a Replacement with the results of the map', function() {
-      var repl = Replacement.map(nodeArrayPath, function(nodePath) {
+      const repl = Replacement.map(nodeArrayPath, function(nodePath) {
         if (nodePath === from1) {
           return Replacement.swaps(nodePath, to1);
         } else if (nodePath === from2) {
           return Replacement.swaps(nodePath, to2);
         } else {
-          assert.ok(false, 'unexpected argument to callback: ' + nodePath);
+          assert.ok(false, `unexpected argument to callback: ${nodePath}`);
         }
       });
 
@@ -97,13 +97,13 @@ describe('Replacement', function() {
     });
 
     it('ignores null returns from the callback', function() {
-      var repl = Replacement.map(nodeArrayPath, function(nodePath) {
+      const repl = Replacement.map(nodeArrayPath, function(nodePath) {
         if (nodePath === from1) {
           return Replacement.swaps(nodePath, to1);
         } else if (nodePath === from2) {
           return null;
         } else {
-          assert.ok(false, 'unexpected argument to callback: ' + nodePath);
+          assert.ok(false, `unexpected argument to callback: ${nodePath}`);
         }
       });
 
@@ -117,9 +117,9 @@ describe('Replacement', function() {
 
   describe('#and', function() {
     it('adds the given Replacement to the receiver', function() {
-      var node1 = {};
-      var anotherNodePath = makeNodePath();
-      var repl = Replacement.swaps(
+      const node1 = {};
+      const anotherNodePath = makeNodePath();
+      const repl = Replacement.swaps(
         nodePath, node1
       ).and(
         Replacement.removes(anotherNodePath)


### PR DESCRIPTION
- declarations.block-scope: Transform `var` into `let` and `const` as appropriate.
- functions.arrow         : Transform regular functions to arrow functions as appropriate.
- objects.concise         : Use concise object property method syntax.
- objects.destructuring   : Transform some declarations and assignments to the more compact destructuring form.
- objects.shorthand       : Use shorthand notation for object properties.
- strings.template        : Transforms manual string concatenation into template strings.

PowerShell script for this:
```ps1
> pnpm install -g esnext

❯ $all= (ls -r )
>> foreach($obj in $all) {
>> if ($obj.extension -eq '.js') {
>> $file = $obj.fullname
>> esnext -o $file $file -b modules.commonjs
>> }
>> }
```